### PR TITLE
add workaround for CPython's incorrect handling of native utf-8 with 8-bit CTE

### DIFF
--- a/eml2pdf/libeml2pdf.py
+++ b/eml2pdf/libeml2pdf.py
@@ -213,7 +213,7 @@ def embed_imgs(html_content: str, attachments: dict) -> str:
     return html_content
 
 
-def decode_to_str(bytes_content: bytes, content_charset: str) -> str:
+def decode_to_str(bytes_content: bytes, content_charset: str, is_8bit_cte: bool) -> str:
     """Robustly decode bytes to string with fallback handling.
 
     Implements a multi-stage decoding strategy to handle various email content
@@ -234,6 +234,7 @@ def decode_to_str(bytes_content: bytes, content_charset: str) -> str:
     Args:
         bytes_content (bytes): The raw byte content to decode.
         content_charset (str): The character encoding name (e.g., 'utf-8', 'iso-8859-1').
+        is_8bit_cte (bool): Whether the message uses 8-bit Content-Transfer-Encoding.
 
     Returns:
         str: Decoded string content. May contain replacement characters (�) if
@@ -254,6 +255,17 @@ def decode_to_str(bytes_content: bytes, content_charset: str) -> str:
     if isinstance(bytes_content, bytes):
         logger.debug(f'bytes: {str(bytes_content)[:100]}...')
         logger.debug(f'charset: {content_charset}')
+
+        # workaround for CPython's incorrect handling of native utf-8 with 8-bit CTE
+        # https://bugs.python.org/issue18271
+        # https://github.com/python/cpython/issues/105285
+        # https://github.com/python/cpython/pull/105306
+        if is_8bit_cte:
+            try:
+                decoded = bytes_content.decode('raw-unicode-escape', errors='strict')
+                bytes_content = decoded.encode()
+            except UnicodeDecodeError, UnicodeEncodeError:
+                pass
         
         try:
             # Attempt strict decoding
@@ -349,7 +361,7 @@ def walk_eml(msg: email.message.Message, eml_path: Path) -> \
         if (content_type == 'text/plain' or content_type == 'text/html') and \
            (content_disposition is None or content_disposition == 'inline'):
             
-            decoded_payload = decode_to_str(payload, content_charset)
+            decoded_payload = decode_to_str(payload, content_charset, is_8bit_cte=_is_8bit_cte(part))
             
             if content_type == 'text/plain':
                 plain_text_content += decoded_payload
@@ -726,3 +738,14 @@ def process_all_emls(input_dir: Path, output_dir: Path, number_of_procs: int,
             p.starmap(process_eml, p_args)
 
     print("All .eml files processed.")
+
+
+def _is_8bit_cte(message: email.message.Message) -> bool:
+    """whether the message uses 8-bit Content-Transfer-Encoding"""
+    cte = message.get('content-transfer-encoding', '')
+    if hasattr(cte, 'cte'):
+        cte = cte.cte
+    else:
+        # cte might be a Header, so for now stringify it.
+        cte = str(cte).strip().lower()
+    return cte == '8bit'

--- a/tests/test_data/plain_native_utf8.eml
+++ b/tests/test_data/plain_native_utf8.eml
@@ -1,0 +1,11 @@
+From: <someone@somewhere.localdomain>
+To: <someone@somewhere.localdomain>
+Subject: Foobar
+Date: Thu, 14 Aug 2025 04:10:53 -0600
+MIME-Version: 1.0
+Message-ID: <b65a6284-9b2d-4edc-bdef-8efa39309a57@somewhere.localdomain>
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 8bit
+
+Falsches Üben von Xylophonmusik quält jeden größeren Zwerg
+

--- a/tests/test_data/plain_native_utf8.html
+++ b/tests/test_data/plain_native_utf8.html
@@ -1,0 +1,2 @@
+<p>Falsches Üben von Xylophonmusik quält jeden größeren Zwerg</p>
+

--- a/tests/test_encodings.py
+++ b/tests/test_encodings.py
@@ -73,13 +73,15 @@ class TestEmls(unittest.TestCase):
     def test_plain_text(self):
         """Plain text file body should render as html."""
         pt_emls = [
-                ('plain_lorem_ipsum.eml',
-                 get_tgt_html(Path('plain_lorem_ipsum.html'))),
-                ('plain_text.eml',
-                 get_tgt_html(Path('plain_text.html'))),
-                ('mixed_plain_html_smiley_embedded.eml',
-                 get_tgt_html(Path('mixed_plain_html_smiley_embedded.html'))),
-                ]
+            ('plain_lorem_ipsum.eml',
+             get_tgt_html(Path('plain_lorem_ipsum.html'))),
+            ('plain_text.eml',
+             get_tgt_html(Path('plain_text.html'))),
+            ('mixed_plain_html_smiley_embedded.eml',
+             get_tgt_html(Path('mixed_plain_html_smiley_embedded.html'))),
+            ('plain_native_utf8.eml',
+             get_tgt_html(Path('plain_native_utf8.html'))),
+        ]
 
         for eml in pt_emls:
             with open(eml_path / Path(eml[0])) as f:


### PR DESCRIPTION
I noticed that some of my emails, which can be correctly rendered in email clients (Thunderbird, Outlook), contain charset encoding errors when converted to a PDF with this tool. This pull request fixes this issue.

The emails with this error contain the following headers, followed by utf-8 encoded payload:
```
Content-Type: text/plain; charset="utf-8"
Content-Transfer-Encoding: 8bit
```

I added a test case for this.

This seems to be caused by incorrect handling of this case in the CPython implementation of `message.get_payload(decode=True)`.

My expectation to this software would be to produce output similar to an email client's "export as PDF" function.

References
* https://bugs.python.org/issue18271
* https://github.com/python/cpython/issues/105285
* https://github.com/python/cpython/pull/105306