### PR TITLE
Add `process_eml_bytes()` for files already loaded to memory

### DIFF
--- a/eml2pdf/libeml2pdf.py
+++ b/eml2pdf/libeml2pdf.py
@@ -694,7 +694,7 @@ def process_all_emls_in_dir(input_dir: Path, output_dir: Path,
 
 def generate_pdf(
     html_content: str,
-    outfile_path: Path,
+    outfile_path: Path | None,
     debug_html: bool = False,
     page: str = 'a4',
     unsafe: bool = False,
@@ -748,7 +748,7 @@ def generate_pdf(
     if not unsafe:
         html_content = security.sanitize_html(html_content)
     try:
-        if debug_html:
+        if debug_html and outfile_path:
             html_file = outfile_path.parent / Path(outfile_path.name + '.html')
             of = open(html_file, 'w', encoding='utf-8')
             of.write(html_content)
@@ -756,14 +756,17 @@ def generate_pdf(
         html = HTML(string=html_content)
         css = CSS(string=f'@page {{ size: {page}; margin: 1cm }}')
 
-        outfile = _get_exclusive_outfile(outfile_path)
+        if outfile_path:
+            outfile = _get_exclusive_outfile(outfile_path)
 
-        html.write_pdf(
-            target=outfile,
-            presentational_hints=True,
-            stylesheets=[css],
-        )
-        logger.info(f"Converted to PDF successfully.")
+            html.write_pdf(
+                target=outfile,
+                presentational_hints=True,
+                stylesheets=[css],
+            )
+            logger.info(f"Converted to PDF successfully.")
+        else:
+            return html.write_pdf(target=None, presentational_hints=True, stylesheets=[css])
     except Exception as e:
         logger.error(f"Failed to convert: {str(e)}")
 

--- a/eml2pdf/libeml2pdf.py
+++ b/eml2pdf/libeml2pdf.py
@@ -621,8 +621,13 @@ def process_eml(eml_path: Path, output_path: Path, page: str = 'a4',
             output_path = _get_output_base_path(email_header.date,
                                                 email_header.subject,
                                                 output_path)
-        generate_pdf(html_content, output_path, eml_path,
-                     debug_html=debug_html, page=page, unsafe=unsafe)
+        generate_pdf(
+            html_content=html_content,
+            outfile_path=output_path,
+            debug_html=debug_html,
+            page=page,
+            unsafe=unsafe,
+        )
     else:
         logger.warning("No plain text or HTML content found "
                        f"in {eml_path}. Skipping...")
@@ -687,9 +692,13 @@ def process_all_emls_in_dir(input_dir: Path, output_dir: Path,
     print("All .eml files processed.")
 
 
-def generate_pdf(html_content: str, outfile_path: Path, infile: Path,
-                 debug_html: bool = False, page: str = 'a4',
-                 unsafe: bool = False):
+def generate_pdf(
+    html_content: str,
+    outfile_path: Path,
+    debug_html: bool = False,
+    page: str = 'a4',
+    unsafe: bool = False,
+):
     """Convert HTML content to PDF with optional sanitization.
 
     Generates a PDF from HTML content using WeasyPrint. By default, sanitizes
@@ -706,7 +715,6 @@ def generate_pdf(html_content: str, outfile_path: Path, infile: Path,
     Args:
         html_content (str): The HTML content to convert to PDF.
         outfile_path (Path): Desired output file path.
-        infile (Path): Input EML file path (for logging/messages).
         debug_html (bool, optional): If True, saves HTML to {outfile}.html for
             debugging. Defaults to False.
         page (str, optional): Page size for PDF (e.g., 'a4', 'letter').
@@ -750,11 +758,14 @@ def generate_pdf(html_content: str, outfile_path: Path, infile: Path,
 
         outfile = _get_exclusive_outfile(outfile_path)
 
-        html.write_pdf(outfile, presentational_hints=True,
-                       stylesheets=[css])
-        logger.info(f"Converted {infile} to PDF successfully.")
+        html.write_pdf(
+            target=outfile,
+            presentational_hints=True,
+            stylesheets=[css],
+        )
+        logger.info(f"Converted to PDF successfully.")
     except Exception as e:
-        logger.error(f"Failed to convert {infile}: {str(e)}")
+        logger.error(f"Failed to convert: {str(e)}")
 
 
 def header_to_html(header_str: str) -> str:

--- a/eml2pdf/libeml2pdf.py
+++ b/eml2pdf/libeml2pdf.py
@@ -1,6 +1,7 @@
 import email
 import email.utils
 import email.header
+import email.message
 from html import escape
 import re
 import datetime
@@ -58,8 +59,8 @@ class _Email:
         _Header() and _walk_eml() internally.
     """
     def __init__(self, msg: email.message.Message, eml_path: Path):
-        self.header = _Header(msg, eml_path)
-        self.html, self.attachments = _walk_eml(msg, eml_path)
+        self.header = _Header(msg)
+        self.html, self.attachments = _walk_eml(msg)
 
 
 class _Header:
@@ -90,7 +91,7 @@ class _Header:
     formatted_date = "No date."
     date = None
 
-    def __init__(self, msg: email.message.Message, eml_path: Path):
+    def __init__(self, msg: email.message.Message):
         """Parse email message and extract header fields.
 
         Decodes From, To, Subject, and Date headers from the email message.
@@ -111,8 +112,7 @@ class _Header:
             self.to_addr = header_to_html(msg.get("to", "No recipient"))
             self.subject = header_to_html(msg.get("subject", "No subject"))
         except UnicodeError as e:
-            logger.error(f"Failed to decode header field for {eml_path}: "
-                         f"{str(e)}")
+            logger.error(f"Failed to decode header field: {str(e)}")
 
         msg_date = msg.get("date", "")
         self.date = email.utils.parsedate_to_datetime(msg.get("date", "")) \
@@ -249,7 +249,7 @@ def _decode_to_str(bytes_content: bytes, content_charset: str,
     return decoded
 
 
-def _walk_eml(msg: email.message.Message, eml_path: Path) -> \
+def _walk_eml(msg: email.message.Message) -> \
         tuple[str, list[_Attachment]]:
     """Extract and process all MIME parts from an email message.
 
@@ -289,7 +289,6 @@ def _walk_eml(msg: email.message.Message, eml_path: Path) -> \
 
     Args:
         msg (email.message.Message): The parsed email message to walk.
-        eml_path (Path): Path to the EML file (used for logging messages).
 
     Returns:
         tuple[str, list[_Attachment]]: A tuple of (html_content, attachments) where
@@ -545,6 +544,28 @@ def _get_cte(message: email.message.Message) -> str:
         cte = str(cte).strip().lower()
     return cte
 
+def _generate_html(msg: email.message.Message) -> str:
+    """Generates HTML for a given message.
+
+    Args:
+        message: (email.message.Message): Email message to generate HTML for.
+
+    Returns (str): The email as HTML
+    """
+    email_header = _Header(msg)
+    html_content, attachments = _walk_eml(msg)
+    attachment_list = _generate_attachment_list(attachments)
+    # Add UTF-8 meta tag and email header if not present
+    if isinstance(html_content, str):
+        html_content = f"""
+<meta charset="UTF-8">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+{email_header.html}
+{attachment_list}
+<hr>
+{html_content}
+"""
+    return email_header, html_content
 
 def process_eml(eml_path: Path, output_path: Path, page: str = 'a4',
                 debug_html: bool = False, unsafe: bool = False):
@@ -592,23 +613,10 @@ def process_eml(eml_path: Path, output_path: Path, page: str = 'a4',
         with open(eml_path, "r", encoding="utf-8") as f:
             msg = email.message_from_file(f)
 
-    email_header = _Header(msg, eml_path)
-    html_content, attachments = _walk_eml(msg, eml_path)
-    attachment_list = _generate_attachment_list(attachments)
+    email_header, html_content = _generate_html(msg)
 
     # Convert to PDF if HTML content is found
     if html_content:
-        # Add UTF-8 meta tag and email header if not present
-        if isinstance(html_content, str):
-            html_content = f"""
-<meta charset="UTF-8">
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-{email_header.html}
-{attachment_list}
-<hr>
-{html_content}
-"""
-
         if output_path.is_dir():
             output_path = _get_output_base_path(email_header.date,
                                                 email_header.subject,

--- a/eml2pdf/libeml2pdf.py
+++ b/eml2pdf/libeml2pdf.py
@@ -15,6 +15,7 @@ import logging
 from multiprocessing import Pool
 import hashlib
 from dataclasses import dataclass
+from typing import overload
 
 from weasyprint import HTML, CSS  # type: ignore
 from markdown import markdown
@@ -632,6 +633,28 @@ def process_eml(eml_path: Path, output_path: Path, page: str = 'a4',
         logger.warning("No plain text or HTML content found "
                        f"in {eml_path}. Skipping...")
 
+def process_eml_bytes(contents: bytes, page: str = 'a4', debug_html: bool = False, unsafe: bool = False) -> bytes:
+    """Generates a PDF from an EML file in memory.
+
+    Same as process_eml() but accepts and returns bytes instead of files.
+
+    Args:
+        contents (bytes): The bytes of the eml file
+        page (str, optional): PDF page size. Defaults to 'a4'.
+        debug_html (bool, optional): Save HTML to disk for debugging.
+          Defaults to False.
+        unsafe (bool, optional): Skip HTML sanitization. Defaults to False.
+
+    Returns (bytes): The bytes of a valid PDF file.
+    """
+    message = email.message_from_bytes(contents)
+    _, html_content = _generate_html(message)
+    return generate_pdf(
+        html_content=html_content,
+        page=page,
+        unsafe=unsafe,
+    )
+
 
 def process_all_emls_in_dir(input_dir: Path, output_dir: Path,
                             number_of_procs: int = 1,
@@ -692,13 +715,33 @@ def process_all_emls_in_dir(input_dir: Path, output_dir: Path,
     print("All .eml files processed.")
 
 
+@overload
 def generate_pdf(
+    *,
     html_content: str,
-    outfile_path: Path | None,
+    outfile_path: Path,
     debug_html: bool = False,
     page: str = 'a4',
     unsafe: bool = False,
-):
+) -> None:
+    pass
+
+@overload
+def generate_pdf(
+    *,
+    html_content: str,
+    page: str = 'a4',
+    unsafe: bool = False,
+) -> bytes:
+    pass
+
+def generate_pdf(
+    html_content: str,
+    outfile_path: Path | None = None,
+    debug_html: bool = False,
+    page: str = 'a4',
+    unsafe: bool = False,
+) -> bytes | None:
     """Convert HTML content to PDF with optional sanitization.
 
     Generates a PDF from HTML content using WeasyPrint. By default, sanitizes

--- a/tests/test_encodings.py
+++ b/tests/test_encodings.py
@@ -87,7 +87,7 @@ class TestEmls(unittest.TestCase):
             with open(eml_path / Path(eml[0]), 'rb') as f:
                 eml_msg = email.message_from_binary_file(f)
             with self.subTest(eml=eml[0]):
-                eml_html = libeml2pdf._walk_eml(eml_msg, eml[0])[0]
+                eml_html = libeml2pdf._walk_eml(eml_msg)[0]
                 self.assertEqual(eml_html, eml[1].strip())
 
     def test_attachments(self):
@@ -95,7 +95,7 @@ class TestEmls(unittest.TestCase):
         at_eml = 'attachments.eml'
         with open(eml_path / Path(at_eml), 'rb') as f:
             eml_msg = email.message_from_binary_file(f)
-        ats_from_eml = libeml2pdf._walk_eml(eml_msg, at_eml)[1]
+        ats_from_eml = libeml2pdf._walk_eml(eml_msg)[1]
         for at in ats_from_eml:
             with self.subTest(at=at):
                 name = at.name
@@ -108,15 +108,15 @@ class TestEmls(unittest.TestCase):
                 self.assertEqual(f_size, at.size)
 
     def test_inline_doc_is_captured_as_attachment(self):
-        """Verify that a .doc file with 'Content-Disposition: inline' 
+        """Verify that a .doc file with 'Content-Disposition: inline'
         is correctly identified as an attachment.
         """
         at_eml = 'email_with_doc_attachment.eml'
         with open(eml_path / Path(at_eml), 'rb') as f:
             eml_msg = email.message_from_binary_file(f)
-        attachments_from_eml = libeml2pdf._walk_eml(eml_msg, at_eml)[1]
+        attachments_from_eml = libeml2pdf._walk_eml(eml_msg)[1]
         # Check if the .doc was found in the attachments list
-        self.assertEqual(len(attachments_from_eml), 1, f"Should have found 1 attachment {attachments_from_eml}") 
+        self.assertEqual(len(attachments_from_eml), 1, f"Should have found 1 attachment {attachments_from_eml}")
 
     def test_plain_and_html_inline(self):
         """Emls with both plain text and html inline parts render once."""
@@ -124,7 +124,7 @@ class TestEmls(unittest.TestCase):
                    get_tgt_html(Path('plain_and_html_inline.html')))
         with open(eml_path / Path(phi_eml[0]), 'rb') as f:
             eml_msg = email.message_from_binary_file(f)
-            eml_html = libeml2pdf._walk_eml(eml_msg, phi_eml)[0]
+            eml_html = libeml2pdf._walk_eml(eml_msg)[0]
             self.assertEqual(eml_html.strip(), phi_eml[1].strip())
 
 

--- a/tests/test_libeml2pdf.py
+++ b/tests/test_libeml2pdf.py
@@ -25,6 +25,30 @@ class TestProcessEml(unittest.TestCase):
         self.assertTrue(self.output_pdf.exists())
         self.assertGreater(self.output_pdf.stat().st_size, 0)
 
+class TestProcessEmlBytes(unittest.TestCase):
+    """Test the process_eml_bytes function."""
+
+    def setUp(self):
+        self.test_dir = Path(tempfile.mkdtemp())
+        self.test_eml = test_eml_path / 'plain_text.eml'
+        self.output_pdf = self.test_dir / "output.pdf"
+
+    def tearDown(self):
+        """Clean up test environment."""
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+
+    def test_process_eml_basic(self):
+        # First, process the eml as a file as usual.
+        libeml2pdf.process_eml(self.test_eml, self.output_pdf)
+        self.assertTrue(self.output_pdf.exists())
+        self.assertGreater(self.output_pdf.stat().st_size, 0)
+
+        # Now process the raw bytes and ensure they match
+        pdf_bytes = self.test_eml.read_bytes()
+        file_output = self.output_pdf.read_bytes()
+        bytes_output = libeml2pdf.process_eml_bytes(pdf_bytes)
+        self.assertEqual(file_output, bytes_output)
+
 class TestProcessAllEmlsInDir(unittest.TestCase):
     """Test the process_all_emls_in_dir function."""
 


### PR DESCRIPTION
If we have an EML file in-memory, and want to output to a PDF and then manipulate it in memory, we currently need to:
- write the EML to disk (1)
- call `process_eml()`, which reads the EML from disk (2) and writes the PDF to disk (3)
- read the PDF from disk (4)

This PR refactors all the non-IO logic out of `process_eml()` so it can be re-used in `process_eml_bytes()`, resulting in 0 disk reads.

You'll probably want to review this PR commit-by-commit for simplicity. Here is the main test case that verifies the behavior:

```python
    def test_process_eml_basic(self):
        # First, process the eml as a file as usual.
        libeml2pdf.process_eml(self.test_eml, self.output_pdf)
        self.assertTrue(self.output_pdf.exists())
        self.assertGreater(self.output_pdf.stat().st_size, 0)

        # Now process the raw bytes and ensure they match
        pdf_bytes = self.test_eml.read_bytes()
        file_output = self.output_pdf.read_bytes()
        bytes_output = libeml2pdf.process_eml_bytes(pdf_bytes)
        self.assertEqual(file_output, bytes_output)
```

After testing that `process_eml_bytes() == read(process_eml(write()))`, the PR relies on the other tests for actual correctness.

Closes #9 